### PR TITLE
feat: Add boolean to check if movement is part of a multijump

### DIFF
--- a/app/MovementFinder.hs
+++ b/app/MovementFinder.hs
@@ -4,8 +4,8 @@ import GameState
 import Control.Lens
 import Utils
 
-findValidMoves :: GameState -> GameState
-findValidMoves state = case state ^. selected of
+findValidMoves :: GameState -> Bool -> GameState
+findValidMoves state isMultiJump = case state ^. selected of
     Nothing -> state
     Just (x, y) -> 
         let cell = getCell x y state
@@ -17,7 +17,7 @@ findValidMoves state = case state ^. selected of
                 else
                     let king = cell ^. isKing
                         direction = getMoveDirections player king
-                    in foldl (\acc (dx, dy) -> checkDirection acc (dx, dy) (x, y) 0 direction) state direction
+                    in foldl (\acc (dx, dy) -> checkDirection acc (dx, dy) (x, y) isMultiJump direction) state direction
 
 
 
@@ -27,15 +27,15 @@ getMoveDirections P2 _ = [(1, -1), (1, 1)]  -- Up-left and up-right for P1
 getMoveDirections P1 _ = [(-1, -1), (-1, 1)] -- Down-left and down-right for P2
 getMoveDirections _ _        = []  -- No valid moves if no player
 
-checkDirection :: GameState -> (Int, Int) -> (Int, Int) -> (Int) -> [(Int, Int)] -> GameState
-checkDirection state (dx, dy) (x, y) numberOfJumps direction
+checkDirection :: GameState -> (Int, Int) -> (Int, Int) -> Bool -> [(Int, Int)] -> GameState
+checkDirection state (dx, dy) (x, y) isMultiJump direction
     | not (isInBounds newX newY) = state -- Out of bounds, return unchaged
-    | isEmpty targetCell && numberOfJumps == 0 = state & matrix . ix newX . ix newY . isAvailable .~ True  -- If empty, mark as valid move
+    | isEmpty targetCell && isMultiJump == False = state & matrix . ix newX . ix newY . isAvailable .~ True  -- If empty, mark as valid move
     | isEnemy targetCell player && isInBounds jumpX jumpY && isEmpty jumpTargetCell = -- if the diagonal has an enemy piece, check if the next cell is empty
         let 
             newState = state & matrix . ix jumpX . ix jumpY . isAvailable .~ True -- Mark it as available
         in 
-            foldl (\acc (dx, dy) -> checkDirection acc (dx, dy) (jumpX, jumpY) (numberOfJumps + 1) direction) newState direction -- Recursively mark all the valid moves
+            foldl (\acc (dx, dy) -> checkDirection acc (dx, dy) (jumpX, jumpY) True direction) newState direction -- Recursively mark all the valid moves
     | otherwise = state -- Ally piece, invalid move
     where
         (newX, newY) = (x + dx, y + dy) 

--- a/app/test/TestMovementFinder.hs
+++ b/app/test/TestMovementFinder.hs
@@ -70,7 +70,7 @@ createTestState1 = GameState
 testFindValidMoves1 :: Test
 testFindValidMoves1 = TestCase $ do
     let initialState = createTestState1  
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 1 !! 0
     let cell2 = (newState ^. matrix) !! 1 !! 2
@@ -100,7 +100,7 @@ createTestState2 = GameState
 testFindValidMoves2 :: Test
 testFindValidMoves2 = TestCase $ do
     let initialState = createTestState2 
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 1 !! 0
     let cell2 = (newState ^. matrix) !! 1 !! 2
@@ -130,7 +130,7 @@ createTestState3 = GameState
 testFindValidMoves3 :: Test
 testFindValidMoves3 = TestCase $ do
     let initialState = createTestState3
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
 
     let cell1 = (newState ^. matrix) !! 1 !! 0
@@ -163,7 +163,7 @@ createTestState4 = GameState
 testFindValidMoves4 :: Test
 testFindValidMoves4 = TestCase $ do
     let initialState = createTestState4  -- your initial game state with P1 at (0, 1)
-    let newState = findValidMoves initialState  -- assuming findValidMoves updates the state
+    let newState = findValidMoves initialState False  -- assuming findValidMoves updates the state
 
     -- Ensure we're not getting out-of-bounds errors, with !! we need to be sure the indices are correct.
     let cell1 = (newState ^. matrix) !! 1 !! 0
@@ -198,7 +198,7 @@ createTestState5 = GameState
 testFindValidMoves5 :: Test
 testFindValidMoves5 = TestCase $ do
     let initialState = createTestState5  
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
 
     let cell1 = (newState ^. matrix) !! 2 !! 2
@@ -231,7 +231,7 @@ createTestState6 = GameState
 testFindValidMoves6 :: Test
 testFindValidMoves6 = TestCase $ do
     let initialState = createTestState6
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 0 !! 2
     let cell2 = (newState ^. matrix) !! 0 !! 1
@@ -263,7 +263,7 @@ createTestState7 = GameState
 testFindValidMoves7 :: Test
 testFindValidMoves7 = TestCase $ do
     let initialState = createTestState7
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 2 !! 5
     let cell2 = (newState ^. matrix) !! 2 !! 3
@@ -295,7 +295,7 @@ createTestState8 = GameState
 testFindValidMoves8 :: Test
 testFindValidMoves8 = TestCase $ do
     let initialState = createTestState8
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 2 !! 3
     let cell2 = (newState ^. matrix) !! 1 !! 2
@@ -326,7 +326,7 @@ createTestState9 = GameState
 testFindValidMoves9 :: Test
 testFindValidMoves9 = TestCase $ do
     let initialState = createTestState9
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 2 !! 5
     let cell2 = (newState ^. matrix) !! 1 !! 4
@@ -395,7 +395,7 @@ createTestState10 = GameState
 testFindValidMoves10 :: Test
 testFindValidMoves10 = TestCase $ do
     let initialState = createTestState10
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 3 !! 3
     let cell2 = (newState ^. matrix) !! 2 !! 2
@@ -430,7 +430,7 @@ createTestState11 = GameState
 testFindValidMoves11 :: Test
 testFindValidMoves11 = TestCase $ do
     let initialState = createTestState11
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 3 !! 3
     let cell2 = (newState ^. matrix) !! 2 !! 2
@@ -465,7 +465,7 @@ createTestState12 = GameState
 testFindValidMoves12 :: Test
 testFindValidMoves12 = TestCase $ do
     let initialState = createTestState12
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 3 !! 3
     let cell2 = (newState ^. matrix) !! 1 !! 5
@@ -502,7 +502,7 @@ createTestState13 = GameState
 testFindValidMoves13 :: Test
 testFindValidMoves13 = TestCase $ do
     let initialState = createTestState13
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 5 !! 2
     let cell2 = (newState ^. matrix) !! 4 !! 3
@@ -537,13 +537,14 @@ createTestState14 = GameState
 testFindValidMoves14 :: Test
 testFindValidMoves14 = TestCase $ do
     let initialState = createTestState14
-    let newState = findValidMoves initialState  
+    let newState = findValidMoves initialState False  
 
     let cell1 = (newState ^. matrix) !! 5 !! 2
     let cell2 = (newState ^. matrix) !! 4 !! 3
     let cell3 = (newState ^. matrix) !! 3 !! 4
     let cell4 = (newState ^. matrix) !! 2 !! 3
     let cell5 = (newState ^. matrix) !! 1 !! 2
+    let cell6 = (newState ^. matrix) !! 4 !! 1
 
 
 
@@ -552,3 +553,43 @@ testFindValidMoves14 = TestCase $ do
     assertEqual "Cell at (3, 4) should be isAvailable, it has a capture" True (cell3 ^. isAvailable)
     assertEqual "Cell at (2, 3) should be unisAvailable, it has enemy piece" False (cell4 ^. isAvailable)
     assertEqual "Cell at (1, 2) should be isAvailable, it has multi capture" True (cell5 ^. isAvailable)
+    assertEqual "Cell at (4, 1) should be isAvailable, it is an empty diagonal" True (cell6 ^. isAvailable)
+
+
+--- Testing MultiJump Version Only
+
+createTestState15 :: GameState
+createTestState15 = GameState
+    { _matrix = [[noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece]
+               , [noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece]
+               , [noPiece, noPiece, noPiece, player2, noPiece, noPiece, noPiece, noPiece]
+               , [noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece]
+               , [noPiece, noPiece, noPiece, player2, noPiece, noPiece, noPiece, noPiece]
+               , [noPiece, noPiece, player1, noPiece, noPiece, noPiece, noPiece, noPiece]
+               , [noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece]
+               , [noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece, noPiece]
+               ]
+    , _turn = P1
+    , _selected = Just (5, 2)  
+    }
+
+testFindValidMoves15 :: Test
+testFindValidMoves15 = TestCase $ do
+    let initialState = createTestState15
+    let newState = findValidMoves initialState True  
+
+    let cell1 = (newState ^. matrix) !! 5 !! 2
+    let cell2 = (newState ^. matrix) !! 4 !! 3
+    let cell3 = (newState ^. matrix) !! 3 !! 4
+    let cell4 = (newState ^. matrix) !! 2 !! 3
+    let cell5 = (newState ^. matrix) !! 1 !! 2
+    let cell6 = (newState ^. matrix) !! 4 !! 1
+
+
+
+    assertEqual "Cell at (2, 5) should be unisAvailable, it's the own piece" False (cell1 ^. isAvailable)
+    assertEqual "Cell at (4, 3) should be unisAvailable, it has enemy piece" False (cell2 ^. isAvailable)
+    assertEqual "Cell at (3, 4) should be isAvailable, it has a capture" True (cell3 ^. isAvailable)
+    assertEqual "Cell at (2, 3) should be unisAvailable, it has enemy piece" False (cell4 ^. isAvailable)
+    assertEqual "Cell at (1, 2) should be isAvailable, it has multi capture" True (cell5 ^. isAvailable)
+    assertEqual "Cell at (4, 1) should not be available, it is an empty diagonal" False (cell6 ^. isAvailable)

--- a/app/test/TestRunner.hs
+++ b/app/test/TestRunner.hs
@@ -14,6 +14,6 @@ main = do
       testFindValidMoves4, testFindValidMoves5, testFindValidMoves6,
        testFindValidMoves7, testFindValidMoves8, testFindValidMoves9,
        testFindValidMoves10, testFindValidMoves11, testFindValidMoves12,
-       testFindValidMoves13, testFindValidMoves14])  
+       testFindValidMoves13, testFindValidMoves14, testFindValidMoves15])  
 
 -- 'cabal test' to execute


### PR DESCRIPTION
When making a movement, if there are more pieces to be captured, call findValidMoves with True in isMultiJump.